### PR TITLE
Fix segmentation fault when handling exceptions in SC3. Improve testing README

### DIFF
--- a/server/scriptcore/ScriptCore3.pas
+++ b/server/scriptcore/ScriptCore3.pas
@@ -416,6 +416,7 @@ begin
       end
       else
       begin
+        Error := Self.FExec.Exec.ExceptionCode;
         if Assigned(Self.FUnit.ScriptUnit.OnUnhandledException) then
           if Self.CallEvent(Self.FUnit.ScriptUnit.OnUnhandledException,
             [Error, E.Message, '', FunctionName, 0, 0]) then

--- a/server/scriptcore/test/README.md
+++ b/server/scriptcore/test/README.md
@@ -37,7 +37,11 @@ To run the tests with CMake, make sure to have `BUILD_SCRIPTCORE` and
 `ADD_FFI_FUZZ` options set to true. Then build CMake target `gen-ffi-fuzz`
 (or run `gen_ffi_tests.py` manually), build and run soldatserver.
 
-To run the tests with another build system, run `gen_ffi_tests.py`, copy
-`ScriptFFITests.pas` to the `scriptcore` directory (temporary), build
-soldatserver with `-dSCRIPT_FFI_FUZZ`, and copy the `ffi` directory to the
-`scripts` directory of your soldatserver.
+To run the tests with another build system:
+1. run `./gen_ffi_tests.py`
+2. Now you need to tell your compiler how to find `ScriptFFITests.pas`.
+You have 2 options:
+   - temporarily copy `ScriptFFITests.pas` to the `server/scriptcore` directory
+   - add `server/scriptcore/test` directory to search paths of units (`-Fu` parameter)
+3. build soldatserver with `-dSCRIPT_FFI_FUZZ` custom option
+4. copy the `ffi` directory to the `scripts` directory of your soldatserver build

--- a/server/scriptcore/test/README.md
+++ b/server/scriptcore/test/README.md
@@ -38,10 +38,10 @@ To run the tests with CMake, make sure to have `BUILD_SCRIPTCORE` and
 (or run `gen_ffi_tests.py` manually), build and run soldatserver.
 
 To run the tests with another build system:
-1. run `./gen_ffi_tests.py`
+1. Run `./gen_ffi_tests.py`
 2. Now you need to tell your compiler how to find `ScriptFFITests.pas`.
 You have 2 options:
-   - temporarily copy `ScriptFFITests.pas` to the `server/scriptcore` directory
-   - add `server/scriptcore/test` directory to search paths of units (`-Fu` parameter)
-3. build soldatserver with `-dSCRIPT_FFI_FUZZ` custom option
-4. copy the `ffi` directory to the `scripts` directory of your soldatserver build
+   - Temporarily copy `ScriptFFITests.pas` to the `server/scriptcore` directory
+   - Add `server/scriptcore/test` directory to search paths of units (`-Fu` parameter)
+3. Build soldatserver with `-dSCRIPT_FFI_FUZZ` custom option
+4. Copy the `ffi` directory to the `scripts` directory of your soldatserver build


### PR DESCRIPTION
Steps to reproduce:
- Adjust BFT so it raises an unhandled exception (there are some commented lines to enable an exception; when testing this, I moved that code to `MyOnPlayerSpeak` handler, so I could raise an exception at any moment). Also, make sure that `Debug` is NOT set to 1 in `bft/config.ini` file, in `[Config]` section
- Build soldatserver with BFT
- Run soldatserver
- Raise exception

Current result:
Server terminates because of a segmentation fault, caused by use of uninitialized variable

Expected result:
Server displays information about unhandled exception in BFT script, disables BFT, and continues to operate

---
I'm also including some further improvements of README for FFI tests